### PR TITLE
Add commit ID to footer

### DIFF
--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -8,6 +8,7 @@ const screenIcon = computed(() => getIsMd.value ? 'i-heroicons-computer-desktop'
 
 <template>
   <footer class="flex flex-row items-center justify-between text-xs text-gray-600 p-4 border-t-2">
+    <span>Theslope v {{ $config.public.COMMIT_ID?.substring(0, 7) }}</span>
     <span>Created with  🦄 & 🌈</span>
     <span>Copyright @themathmagician  @2025 </span>
     <span><Icon :name="screenIcon" size="lg" class="ml-auto"/></span>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,7 +39,8 @@ export default defineNuxtConfig({
         // Public keys that are exposed to the client
         public: {
             apiBase: '/api',
-            HEY_NABO_API: process.env.NUXT_HEY_NABO_API || '' //Set in NUXT_HEYNABO_API env variable
+            HEY_NABO_API: process.env.NUXT_HEY_NABO_API || '', //Set in NUXT_HEYNABO_API env variable
+            COMMIT_ID: process.env.GITHUB_SHA || 'development'
         }
     },
 


### PR DESCRIPTION
## Summary
- Added COMMIT_ID to public runtime config using GITHUB_SHA environment variable
- Updated PageFooter component to display commit version
- Shows as "Theslope v [7-char-hash]" format in footer

## Test plan
- [x] Footer displays commit ID in development
- [ ] Production deployment will show proper GITHUB_SHA commit hash